### PR TITLE
feat: Add universal synthesis agent

### DIFF
--- a/chains.py
+++ b/chains.py
@@ -3,7 +3,7 @@ from langchain_core.output_parsers import StrOutputParser
 from prompts import (
     chat_prompt, triage_prompt, ingestion_prompt,
     takeout_prompt, transaction_prompt, wellness_prompt,
-    home_event_prompt, calendar_event_prompt
+    home_event_prompt, calendar_event_prompt, synthesis_prompt
 )
 
 try:
@@ -20,6 +20,7 @@ try:
     wellness_chain = wellness_prompt | llm | StrOutputParser() # Expects a single string response
     home_event_chain = home_event_prompt | llm
     calendar_event_chain = calendar_event_prompt | llm
+    synthesis_chain = synthesis_prompt | llm | StrOutputParser()
 
     print("✅ LLM and chains are initialized successfully.")
 
@@ -34,3 +35,4 @@ except Exception as e:
     wellness_chain = None
     home_event_chain = None
     calendar_event_chain = None
+    synthesis_chain = None

--- a/prompts.py
+++ b/prompts.py
@@ -110,3 +110,13 @@ Classify the event into one of the following categories: 'Work Meeting', 'Person
 Return a single JSON object with the key 'category'."""),
     ("user", "Please categorize the following calendar event:\n\n{event_details}\n\nNow, provide the category as a JSON object.")
 ])
+
+synthesis_prompt = ChatPromptTemplate.from_messages([
+        ("system", """You are a personal chief of staff. Your task is to analyze a list of structured data items and write a concise, conversational summary. Do not just list the counts; create a brief, easy-to-read narrative that highlights important trends or specific items that require attention. Your tone should be professional yet friendly.
+
+The report you are generating is for: '{report_type}'."""),
+("user", """Here is the data for your report:
+{data_as_string}
+
+Now, please provide your narrative summary.""")
+])

--- a/routers/context_agents.py
+++ b/routers/context_agents.py
@@ -5,11 +5,13 @@ from schemas import (
     TransactionRequest, TransactionResponse,
     WellnessSummaryRequest, WellnessSummaryResponse,
     HomeEventRequest, HomeEventResponse,
-    CalendarEventRequest, CalendarEventResponse
+    CalendarEventRequest, CalendarEventResponse,
+    SynthesisRequest, SynthesisResponse
 )
 from chains import (
     transaction_chain, wellness_chain,
-    home_event_chain, calendar_event_chain
+    home_event_chain, calendar_event_chain,
+    synthesis_chain
 )
 
 router = APIRouter(
@@ -75,3 +77,17 @@ def process_calendar_event_endpoint(request: CalendarEventRequest):
         }
     except json.JSONDecodeError:
         return {"error": f"Failed to parse LLM response as JSON. Output: {response.content}"}, 500
+
+@router.post("/synthesize_report", response_model=SynthesisResponse)
+def synthesize_report_endpoint(request: SynthesisRequest):
+    if synthesis_chain is None:
+        return {"error": "LLM synthesis_chain is not initialized."}, 500
+
+    data_as_string = json.dumps(request.data, indent=2)
+
+    report_text = synthesis_chain.invoke({
+        "report_type": request.report_type,
+        "data_as_string": data_as_string
+    })
+
+    return {"report_text": report_text}

--- a/schemas.py
+++ b/schemas.py
@@ -77,3 +77,10 @@ class CalendarEventRequest(BaseModel):
 class CalendarEventResponse(BaseModel):
     category: str
     original_event: CalendarEventRequest
+
+class SynthesisRequest(BaseModel):
+    report_type: str
+    data: List[dict]
+
+class SynthesisResponse(BaseModel):
+    report_text: str


### PR DESCRIPTION
This commit introduces a new "Synthesis Agent" to the application. This agent provides a generic endpoint for creating narrative reports from any list of structured data.

Changes include:
- Added `SynthesisRequest` and `SynthesisResponse` models to `schemas.py`.
- Created a new `synthesis_prompt` in `prompts.py` for generating narrative summaries.
- Added the corresponding `synthesis_chain` in `chains.py`.
- Implemented the `/context/synthesize_report` endpoint in `routers/context_agents.py`.

This universal agent replaces the need for specific summary agents and will serve as a high-level reporting tool.